### PR TITLE
Generate Cargo build files and make the crate template more accepting

### DIFF
--- a/grust/generators/sys_cargo.py
+++ b/grust/generators/sys_cargo.py
@@ -29,7 +29,9 @@ class SysCargoWriter(object):
         self._mapper = mapper
         self._transformer = transformer
         self._cargo_template = tmpl_lookup.get_template('cargo/cargo.tmpl')
+        self._build_rs_template = tmpl_lookup.get_template('cargo/build.rs.tmpl')
         self._cargo_file = os.path.join(path, 'Cargo.toml')
+        self._build_rs_file = os.path.join(path, 'build.rs')
 
     def _write_cargo(self, output):
         pkgname = sys_crate_name(self._transformer.namespace)
@@ -39,10 +41,22 @@ class SysCargoWriter(object):
                                                      version=version)
         output.write(result)
 
+    def _write_build_rs(self, output):
+        pkgconfig_packages = self._transformer.namespace.exported_packages
+        result = self._build_rs_template.render_unicode(packages=pkgconfig_packages)
+        output.write(result)
+
     def write(self):
         cargo_output = FileOutput(self._cargo_file, encoding='utf-8')
         with cargo_output as output:
             try:
                 self._write_cargo(output)
+            except Exception:
+                raise SystemExit(1)
+
+        build_rs_output = FileOutput(self._build_rs_file, encoding='utf-8')
+        with build_rs_output as output:
+            try:
+                self._write_build_rs(output)
             except Exception:
                 raise SystemExit(1)

--- a/grust/generators/sys_cargo.py
+++ b/grust/generators/sys_cargo.py
@@ -1,0 +1,48 @@
+# coding: UTF-8
+# grust-gen - Rust binding generator for GObject introspection
+#
+# Copyright (C) 2016  Jonas Ådahl <jadahl@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
+import os
+from ..mapping import sys_crate_name
+from ..output import FileOutput
+
+class SysCargoWriter(object):
+    """Generator for -sys Cargo build files."""
+
+    def __init__(self, mapper, transformer, tmpl_lookup, path):
+        self._mapper = mapper
+        self._transformer = transformer
+        self._cargo_template = tmpl_lookup.get_template('cargo/cargo.tmpl')
+        self._cargo_file = os.path.join(path, 'Cargo.toml')
+
+    def _write_cargo(self, output):
+        pkgname = sys_crate_name(self._transformer.namespace)
+        version = self._transformer.namespace.version
+        result = self._cargo_template.render_unicode(mapper=self._mapper,
+                                                     pkgname=pkgname,
+                                                     version=version)
+        output.write(result)
+
+    def write(self):
+        cargo_output = FileOutput(self._cargo_file, encoding='utf-8')
+        with cargo_output as output:
+            try:
+                self._write_cargo(output)
+            except Exception:
+                raise SystemExit(1)

--- a/grust/generators/sys_crate.py
+++ b/grust/generators/sys_crate.py
@@ -29,7 +29,7 @@ class SysCrateWriter(object):
                  template,
                  options,
                  gir_filename=None):
-        self._mapper = RawMapper(transformer)
+        self._mapper = RawMapper(transformer, options)
         self._template = template
         self._options = options
         if gir_filename:

--- a/grust/generators/sys_crate.py
+++ b/grust/generators/sys_crate.py
@@ -55,3 +55,6 @@ class SysCrateWriter(object):
                                context=node)
             return False
         return True
+
+    def get_mapper(self):
+        return self._mapper

--- a/grust/genmain.py
+++ b/grust/genmain.py
@@ -57,6 +57,12 @@ def _create_arg_parser():
                         help='name of the custom template file')
     parser.add_argument('-c', '--cargo', dest='gen_cargo', action='store_true',
                         help='generate a Cargo build description')
+    parser.add_argument('--exclude', action='append',
+                        dest='excluded_crates', metavar='DEP',
+                        help='exclude mapping functions relating to this crate')
+    parser.add_argument('--include', action='append',
+                        dest='included_crates', metavar='DEP',
+                        help='include mapping functions relating to this crate')
     return parser
 
 def generator_main():

--- a/grust/genmain.py
+++ b/grust/genmain.py
@@ -29,6 +29,7 @@ from .giscanner.transformer import Transformer
 from .giscanner import message
 from .giscanner import utils
 from .generators.sys_crate import SysCrateWriter
+from .generators.sys_cargo import SysCargoWriter
 from .output import FileOutput, DirectOutput
 from . import __version__ as version
 from .mapping import sys_crate_name
@@ -127,19 +128,11 @@ def generator_main():
             sys.exit('can only generate cargo build description without custom template')
         if not isinstance(output, FileOutput):
             sys.exit('can only generate cargo build description with file output')
+        cargo_path = os.path.dirname(output.filename())
+        cargo_gen = SysCargoWriter(mapper=gen.get_mapper(),
+                                   transformer=transformer,
+                                   tmpl_lookup=tmpl_lookup,
+                                   path=cargo_path)
 
-        cargo_file = os.path.join(os.path.dirname(output.filename()), 'Cargo.toml')
-        cargo_template = tmpl_lookup.get_template('cargo/cargo.tmpl')
-
-        result = cargo_template.render_unicode(mapper=gen.get_mapper(),
-                                               pkgname=sys_crate_name(transformer.namespace),
-                                               version=transformer.namespace.version)
-
-        crate_output = output_file(cargo_file)
-
-        with crate_output as out:
-            try:
-                out.write(result)
-            except Exception:
-                raise SystemExit(1)
+        cargo_gen.write()
     return 0

--- a/grust/mapping.py
+++ b/grust/mapping.py
@@ -476,6 +476,7 @@ def _unwrap_call_signature_ctype(type_container):
     if ctype is None:
         raise MappingError('parameter {}: C type attribute is missing'.format(type_container.argname))
     if (isinstance(type_container, ast.Parameter)
+        and not isinstance(type_container.type, ast.Array)
         and type_container.direction in (ast.PARAM_DIRECTION_OUT,
                                          ast.PARAM_DIRECTION_INOUT)
         and not type_container.caller_allocates):

--- a/grust/output.py
+++ b/grust/output.py
@@ -51,6 +51,9 @@ class FileOutput(object):
                 'newline': newline
             }
 
+    def filename(self):
+        return self._filename
+
     def __enter__(self):
         dirname, basename = os.path.split(self._filename)
         if sys.version_info.major >= 3:

--- a/grust/templates/cargo/build.rs.tmpl
+++ b/grust/templates/cargo/build.rs.tmpl
@@ -1,0 +1,13 @@
+extern crate pkg_config;
+
+const PACKAGES: &'static [ &'static str ] = &[
+%    for package in packages:
+    "${package}",
+%    endfor
+];
+
+fn main() {
+    for package in PACKAGES {
+        pkg_config::probe_library(package).unwrap();
+    }
+}

--- a/grust/templates/cargo/cargo.tmpl
+++ b/grust/templates/cargo/cargo.tmpl
@@ -1,0 +1,22 @@
+[package]
+name = "${pkgname}"
+version = "0.0.1"
+
+[lib]
+path = "lib.rs"
+
+[dependencies.libc]
+git = "https://github.com/rust-lang/libc.git"
+
+[dependencies.grust]
+git = "https://github.com/gi-rust/grust.git"
+
+[dependencies.gtypes]
+git = "https://github.com/gi-rust/gtypes.git"
+
+%   for xc in mapper.extern_crates():
+%       if xc.name is not 'libc':
+[dependencies.${xc.name}]
+path = "../${xc.name}"
+%       endif
+%   endfor

--- a/grust/templates/cargo/cargo.tmpl
+++ b/grust/templates/cargo/cargo.tmpl
@@ -15,7 +15,7 @@ git = "https://github.com/gi-rust/grust.git"
 git = "https://github.com/gi-rust/gtypes.git"
 
 %   for xc in mapper.extern_crates():
-%       if xc.name is not 'libc':
+%       if xc.name is not 'libc' and not mapper.is_excluded(xc):
 [dependencies.${xc.name}]
 path = "../${xc.name}"
 %       endif

--- a/grust/templates/cargo/cargo.tmpl
+++ b/grust/templates/cargo/cargo.tmpl
@@ -1,9 +1,13 @@
 [package]
 name = "${pkgname}"
 version = "0.0.1"
+build = "build.rs"
 
 [lib]
 path = "lib.rs"
+
+[build-dependencies]
+pkg-config = "0.3.7"
 
 [dependencies.libc]
 git = "https://github.com/rust-lang/libc.git"

--- a/grust/templates/sys/crate.tmpl
+++ b/grust/templates/sys/crate.tmpl
@@ -117,7 +117,7 @@ extern crate gtypes;
 %   for xc in mapper.extern_crates():
 %       if xc.name == xc.local_name:
 extern crate ${xc.name};
-%       else:
+%       elif not mapper.is_excluded(xc):
 extern crate ${xc.name} as ${xc.local_name};
 %       endif
 %   endfor

--- a/grust/templates/sys/crate.tmpl
+++ b/grust/templates/sys/crate.tmpl
@@ -93,8 +93,7 @@ def indenter(amount):
             continue
         if node.name in self.attr.ignore_names:
             continue
-        if any(param.type == ast.TYPE_VALIST for param in node.parameters):
-            # Functions with a va_list parameter are usable only in C
+        if not mapper.node_is_mappable(node):
             continue
         functions.append(node)
 
@@ -180,12 +179,16 @@ extern {
         raise ConsistencyError(
             'C type name {} conflicts with a fundamental type'
             .format(node.ctype))
+    if not mapper.node_is_mappable(node):
+        return ''
 %>
 pub type ${node.ctype} = ${mapper.map_aliased_type(node)};
 </%def>\
 ##
 <%def name="callback(node)">
+%    if mapper.node_is_mappable(node):
 pub type ${node.ctype} = ${mapper.map_callback(node)};
+%    endif
 </%def>\
 ##
 <%def name="constant(node)">
@@ -307,11 +310,13 @@ extern {
                         type=mapper.map_parameter_type(param))
                       for param in parameters]
 %>\
+%    if mapper.node_is_mappable(node):
 pub fn ${node.symbol}(${', '.join(param_list)})\
-%   if node.retval.type != ast.TYPE_NONE:
+%       if node.retval.type != ast.TYPE_NONE:
  -> ${mapper.map_return_type(node.retval)}\
-%   endif
+%       endif
 ;
+%   endif
 </%def>\
 ##
 <%def name="cfg_attr(cfg)">\

--- a/grust/templates/sys/crate.tmpl
+++ b/grust/templates/sys/crate.tmpl
@@ -57,6 +57,7 @@ def indenter(amount):
         ast.Constant: constant,
         ast.Record: struct,
         ast.Class: struct,
+        ast.Union: struct,
         ast.Interface: interface,
         ast.Enum: enum,
         ast.Bitfield: flags
@@ -206,11 +207,15 @@ pub struct ${node.ctype}(gpointer);
 pub enum ${node.ctype} { }
 %   else:
 #[repr(C)]
+%       if not mapper.struct_is_valid(node):
+pub struct ${node.ctype};
+%       else:
 pub struct ${node.ctype} {
-%       for field in node.fields:
+%           for field in node.fields:
     ${'' if field.private else 'pub '}${sanitize_ident(field.name)}: ${mapper.map_field_type(field)},
-%       endfor
+%           endfor
 }
+%       endif
 %   endif
 </%def>\
 ##


### PR DESCRIPTION
Hi,

Sorry for the catch-all pull request, but with these patches I can generate for example glib, gio and gtk without any special template (though with plenty of compiler warnings still), while also not having to also generate all the other dependencies those would have. I also have them generate the Cargo.toml and a build.rs to build.

In summary, the patches do
- Adds an option to genaret Cargo.toml and build.rs build file for the -sys crate
- Makes it so that any typedef/alias that ends up with a va_list gets for now silently ignored (since va_lists are not portable compiler/libc specific)
- Makes it so that any struct that contains a bitmask becomes an opaque struct (since there is no portable way to determine the width of the resulting mask).
- Makes it possible to either include a set (default to exclude), or exclude a set (default to include) dependencies when generating a crate. This makes it possible to for example generate the gtk-sys crate without any references to cairo, x11 etc.

Let me know what you think.
